### PR TITLE
Use ndk from project config if available

### DIFF
--- a/package/android/build.gradle
+++ b/package/android/build.gradle
@@ -19,6 +19,15 @@ android {
     namespace "com.turbohaptics"
     compileSdkVersion safeExtGet('compileSdkVersion', 33)
 
+    // Used to override the NDK path/version on internal CI or by allowing
+    // users to customize the NDK path/version from their root project.
+    if (rootProject.hasProperty("ndkPath")) {
+        ndkPath rootProject.ext.ndkPath
+    }
+    if (rootProject.hasProperty("ndkVersion")) {
+        ndkVersion rootProject.ext.ndkVersion
+    }
+
     defaultConfig {
         minSdkVersion safeExtGet('minSdkVersion', 21)
         targetSdkVersion safeExtGet('targetSdkVersion', 33)


### PR DESCRIPTION
I noticed that on CI this library caused a 2nd version of android ndk to be installed. This adds some config to make sure we use the version from the project if specified (taken from https://github.com/AppAndFlow/react-native-safe-area-context/blob/main/android/build.gradle#L52).