### PR TITLE
fix: bring android 16kb support

### DIFF
--- a/package/android/build.gradle
+++ b/package/android/build.gradle
@@ -35,6 +35,7 @@ android {
         externalNativeBuild {
             cmake {
                 cppFlags "-std=c++17"
+                arguments "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON"
             }
         }
     }


### PR DESCRIPTION
PR adding support for Android 16kb builds (see https://android-developers.googleblog.com/2025/05/prepare-play-apps-for-devices-with-16kb-page-size.html?utm_source=email&utm_medium=newsletter&utm_campaign=Play-june25 and e.g. https://github.com/mrousavy/react-native-vision-camera/pull/3543